### PR TITLE
Allow SpringHelper to inject primary beans even if there are more of …

### DIFF
--- a/stripes-spring/src/main/java/org/stripesframework/spring/SpringHelper.java
+++ b/stripes-spring/src/main/java/org/stripesframework/spring/SpringHelper.java
@@ -27,6 +27,8 @@ import javax.servlet.ServletContext;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
@@ -93,12 +95,22 @@ public class SpringHelper {
          }
       } else if ( beanNames.length > 1 ) {
          boolean found = false;
+         final AutowireCapableBeanFactory autowireCapableBeanFactory = ctx.getAutowireCapableBeanFactory();
+         BeanDefinitionRegistry beanDefinitionRegistry = null;
+         if ( autowireCapableBeanFactory instanceof BeanDefinitionRegistry ) {
+            beanDefinitionRegistry = (BeanDefinitionRegistry)autowireCapableBeanFactory;
+         }
          for ( String beanName : beanNames ) {
             if ( beanName.equals(name) ) {
                found = true;
                break;
+            } else if ( beanDefinitionRegistry != null && beanDefinitionRegistry.getBeanDefinition(beanName).isPrimary() ) {
+               found = true;
+               name = beanName;
+               break;
             }
          }
+
          if ( !found ) {
             if ( required ) {
                throw new StripesRuntimeException("Unable to find SpringBean with name [" + name + "] or unique bean with type [" + type.getName()

--- a/stripes-spring/src/main/java/org/stripesframework/spring/SpringHelper.java
+++ b/stripes-spring/src/main/java/org/stripesframework/spring/SpringHelper.java
@@ -104,10 +104,24 @@ public class SpringHelper {
             if ( beanName.equals(name) ) {
                found = true;
                break;
-            } else if ( beanDefinitionRegistry != null && beanDefinitionRegistry.getBeanDefinition(beanName).isPrimary() ) {
+            }
+         }
+
+         if ( !found && beanDefinitionRegistry != null ) {
+            List<String> primaryBeanNames = new ArrayList<>();
+            for ( String beanName : beanNames ) {
+               if ( beanDefinitionRegistry.containsBeanDefinition(beanName) && beanDefinitionRegistry.getBeanDefinition(beanName).isPrimary() ) {
+                  primaryBeanNames.add(beanName);
+               }
+            }
+
+            if ( primaryBeanNames.size() == 1 ) {
                found = true;
-               name = beanName;
-               break;
+               name = primaryBeanNames.get(0);
+            } else if ( primaryBeanNames.size() > 1 ) {
+               throw new StripesRuntimeException(
+                     "Found more than one 'primary' SpringBean of type [" + type.getName() + "] in the Spring application context. Found " + primaryBeanNames
+                           + " as primary beans.");
             }
          }
 


### PR DESCRIPTION
Currently SpringHelper cannot find a unique bean when there are more defined of given type and throws an exception.
With this fix SpringHelper can inject even if given property name does not match the bean name but there is one bean configured as 'primary'. Often given property name does not match anyways because of an undersocore as first char like '_anyService' but bean name is 'anyService'.