### PR TITLE
Upgrade commons-fileupload to 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
 			<dependency>
 				<groupId>commons-fileupload</groupId>
 				<artifactId>commons-fileupload</artifactId>
-				<version>1.3.1</version>
+				<version>1.5</version>
 				<scope>provided</scope>
 				<optional>true</optional>
 			</dependency>

--- a/stripes-web/src/main/java/org/stripesframework/web/controller/multipart/CommonsMultipartWrapper.java
+++ b/stripes-web/src/main/java/org/stripesframework/web/controller/multipart/CommonsMultipartWrapper.java
@@ -82,6 +82,7 @@ public class CommonsMultipartWrapper implements MultipartWrapper {
          factory.setRepository(tempDir);
          ServletFileUpload upload = new ServletFileUpload(factory);
          upload.setSizeMax(maxPostSize);
+         upload.setFileCountMax(1000);
          List<FileItem> items = upload.parseRequest(request);
          Map<String, List<String>> params = new HashMap<>();
 


### PR DESCRIPTION
This fixes CVE-2023-24998.

This count is currently hardcoded to 1000. Adding a parameter would require changes to the interface.