### PR TITLE
Remove HttpServletResponseWrapper hack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>org.stripesframework</groupId>
 	<artifactId>stripes-parent</artifactId>
-	<version>3.0.0-EAP-4</version>
+	<version>3.0.0-EAP-5</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/stripes-jsp/pom.xml
+++ b/stripes-jsp/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.stripesframework</groupId>
       <artifactId>stripes-parent</artifactId>
-      <version>3.0.0-EAP-4</version>
+      <version>3.0.0-EAP-5</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
    <artifactId>stripes-jsp</artifactId>

--- a/stripes-spring/pom.xml
+++ b/stripes-spring/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.stripesframework</groupId>
 		<artifactId>stripes-parent</artifactId>
-		<version>3.0.0-EAP-4</version>
+		<version>3.0.0-EAP-5</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>stripes-spring</artifactId>

--- a/stripes-test-report/pom.xml
+++ b/stripes-test-report/pom.xml
@@ -7,7 +7,7 @@
    <parent>
       <groupId>org.stripesframework</groupId>
       <artifactId>stripes-parent</artifactId>
-      <version>3.0.0-EAP-4</version>
+      <version>3.0.0-EAP-5</version>
    </parent>
 
    <profiles>

--- a/stripes-web/pom.xml
+++ b/stripes-web/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.stripesframework</groupId>
 		<artifactId>stripes-parent</artifactId>
-		<version>3.0.0-EAP-4</version>
+		<version>3.0.0-EAP-5</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>stripes-web</artifactId>

--- a/stripes-web/src/main/java/org/stripesframework/web/action/RedirectResolution.java
+++ b/stripes-web/src/main/java/org/stripesframework/web/action/RedirectResolution.java
@@ -25,7 +25,6 @@ import org.stripesframework.web.util.Log;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpServletResponseWrapper;
 
 
 /**
@@ -114,17 +113,6 @@ public class RedirectResolution extends OnwardResolution<RedirectResolution> {
    @SuppressWarnings("unchecked")
    public void execute( HttpServletRequest request, HttpServletResponse response ) throws ServletException, IOException {
       response.setStatus(_status);
-      response = new HttpServletResponseWrapper(response) {
-
-         @Override
-         public void sendRedirect( String location ) {
-            setHeader("Location", location);
-         }
-
-         @Override
-         public void setStatus( int sc ) {
-         }
-      };
 
       if ( _includeRequestParameters ) {
          addParameters(request.getParameterMap());
@@ -156,7 +144,10 @@ public class RedirectResolution extends OnwardResolution<RedirectResolution> {
       url = response.encodeRedirectURL(url);
       log.trace("Redirecting ", _beans == null ? "" : "(w/flashed bean) ", "to URL: ", url);
 
-      response.sendRedirect(url);
+      response.resetBuffer();
+      response.setStatus(_status);
+      response.setHeader("location", url);
+      response.getOutputStream().close();
    }
 
    /**

--- a/stripes-web/src/test/java/org/stripesframework/web/mock/MockHttpServletResponse.java
+++ b/stripes-web/src/test/java/org/stripesframework/web/mock/MockHttpServletResponse.java
@@ -44,8 +44,8 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MockHttpServletResponse implements HttpServletResponse {
 
-   private final MockServletOutputStream   _out               = new MockServletOutputStream();
-   private final PrintWriter               _writer            = new PrintWriter(_out, true);
+   private       MockServletOutputStream   _out               = new MockServletOutputStream();
+   private       PrintWriter               _writer            = new PrintWriter(_out, true);
    private       Locale                    _locale            = Locale.getDefault();
    private final Map<String, List<Object>> _headers           = new HashMap<>();
    private final List<Cookie>              _cookies           = new ArrayList<>();
@@ -257,7 +257,8 @@ public class MockHttpServletResponse implements HttpServletResponse {
    /** Always throws IllegalStateException. */
    @Override
    public void resetBuffer() {
-      throw new IllegalStateException("reset() is not supported");
+      _out = new MockServletOutputStream();
+      _writer = new PrintWriter(_out, true);
    }
 
    /** Sets the status code and saves the message so it can be retrieved later. */


### PR DESCRIPTION
sendRedirect always sends a 302 status code, this is something the spec says, and we shouldn't try to work around that like we do here.

The redirect logic with calling resetBuffer first is adapted from Jetty 11, but we skipped canonicalization of the URL unlike Jetty.