### PR TITLE
Bump version to 5.0.0-EAP-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>org.stripesframework</groupId>
 	<artifactId>stripes-parent</artifactId>
-	<version>5.0.0-SNAPSHOT</version>
+	<version>5.0.0-EAP-1</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/stripes-jsp/pom.xml
+++ b/stripes-jsp/pom.xml
@@ -6,7 +6,7 @@
    <parent>
       <groupId>org.stripesframework</groupId>
       <artifactId>stripes-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>5.0.0-EAP-1</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/stripes-spring/pom.xml
+++ b/stripes-spring/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.stripesframework</groupId>
 		<artifactId>stripes-parent</artifactId>
-		<version>5.0.0-SNAPSHOT</version>
+		<version>5.0.0-EAP-1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/stripes-test-report/pom.xml
+++ b/stripes-test-report/pom.xml
@@ -7,7 +7,7 @@
    <parent>
       <groupId>org.stripesframework</groupId>
       <artifactId>stripes-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>5.0.0-EAP-1</version>
    </parent>
 
    <properties>

--- a/stripes-web/pom.xml
+++ b/stripes-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.stripesframework</groupId>
 		<artifactId>stripes-parent</artifactId>
-		<version>5.0.0-SNAPSHOT</version>
+		<version>5.0.0-EAP-1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
The 5.x branch is protected, so bumping the version after the fact needs a PR