### PR TITLE
5.0.0 dependencies fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 			<dependency>
 				<groupId>jakarta.servlet</groupId>
 				<artifactId>jakarta.servlet-api</artifactId>
-				<version>6.0.0</version>
+				<version>6.1.0</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
OpenRewrite appears to have missed the servlet-api bump to 6.1. Fix it